### PR TITLE
Add minimal turnip library skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Turnip
 
 > Experiment definition, management, and execution for LLM research
+
+Turnip provides a small framework for orchestrating LLM based
+experiments.  It offers:
+
+- Async wrappers for multiple providers (OpenAI, Together.ai and vLLM)
+- A flexible `TurnProcessor` base class for running multi turn
+  interactions
+- Optional caching of results in a PostgreSQL database
+
+This repository contains a minimal implementation intended to be easily
+extended for research use.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "turnip"
+version = "0.1.0"
+description = "LLM orchestration utilities"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Turnip Team"}]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,57 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from turnip import TurnProcessor
+from turnip.providers.base import LLMProvider
+from turnip.storage import LLMResult
+
+
+class DummyProvider(LLMProvider):
+    def __init__(self):
+        self.calls = 0
+
+    async def completion(self, prompt: str, **kwargs: object) -> str:
+        self.calls += 1
+        return prompt + " response"
+
+
+class MemoryStore:
+    def __init__(self):
+        self.data = {}
+
+    async def fetch(self, prompt):
+        if prompt in self.data:
+            r = self.data[prompt]
+            return LLMResult(prompt, r)
+        return None
+
+    async def insert(self, result):
+        self.data[result.prompt] = result.response
+
+
+class EchoProcessor(TurnProcessor):
+    def render_prompt(self, state):
+        return state
+
+    def update_state(self, state, response):
+        return response
+
+    def stop(self, state):
+        return state.endswith("response")
+
+
+async def run():
+    provider = DummyProvider()
+    store = MemoryStore()
+    proc = EchoProcessor(provider, store)
+    result1 = await proc.process("hello")
+    result2 = await proc.process("hello")
+    assert result1 == result2 == "hello response"
+    assert provider.calls == 1
+
+
+def test_cache():
+    asyncio.run(run())

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,41 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from turnip import TurnProcessor
+from turnip.providers.base import LLMProvider
+
+
+class DummyProvider(LLMProvider):
+    def __init__(self):
+        self.calls = 0
+
+    async def completion(self, prompt: str, **kwargs: object) -> str:
+        self.calls += 1
+        return prompt + " response"
+
+
+class EchoProcessor(TurnProcessor):
+    def render_prompt(self, state):
+        return state
+
+    def update_state(self, state, response):
+        return response
+
+    def stop(self, state):
+        # stop after one turn
+        return state.endswith("response")
+
+
+async def run():
+    provider = DummyProvider()
+    proc = EchoProcessor(provider)
+    result = await proc.process("hello")
+    assert result == "hello response"
+    assert provider.calls == 1
+
+
+def test_echo_processor():
+    asyncio.run(run())

--- a/turnip/__init__.py
+++ b/turnip/__init__.py
@@ -1,0 +1,20 @@
+"""Turnip: simple framework for orchestrating LLM experiments."""
+
+from .processor import TurnProcessor
+from .providers import (
+    LLMProvider,
+    OpenAIProvider,
+    TogetherProvider,
+    VLLMProvider,
+)
+from .storage import ResultStore, LLMResult
+
+__all__ = [
+    "TurnProcessor",
+    "LLMProvider",
+    "OpenAIProvider",
+    "TogetherProvider",
+    "VLLMProvider",
+    "ResultStore",
+    "LLMResult",
+]

--- a/turnip/processor.py
+++ b/turnip/processor.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import abc
+from typing import Any, Optional
+
+from .providers.base import LLMProvider
+from .storage import LLMResult, ResultStore
+
+
+class TurnProcessor(abc.ABC):
+    """Base class for processing an instance using an LLM."""
+
+    def __init__(self, provider: LLMProvider, store: Optional[ResultStore] = None) -> None:
+        self.provider = provider
+        self.store = store
+
+    async def process(self, initial_state: Any) -> Any:
+        state = initial_state
+        while True:
+            prompt = self.render_prompt(state)
+            cached = await self._fetch_cached(prompt)
+            if cached is not None:
+                response = cached.response
+            else:
+                response = await self.provider.completion(prompt)
+                await self._save_result(prompt, response)
+            state = self.update_state(state, response)
+            if self.stop(state):
+                break
+        return state
+
+    async def _fetch_cached(self, prompt: str) -> Optional[LLMResult]:
+        if self.store is None:
+            return None
+        return await self.store.fetch(prompt)
+
+    async def _save_result(self, prompt: str, response: str) -> None:
+        if self.store is None:
+            return
+        await self.store.insert(LLMResult(prompt=prompt, response=response))
+
+    @abc.abstractmethod
+    def render_prompt(self, state: Any) -> str:
+        """Convert the state into a prompt."""
+
+    @abc.abstractmethod
+    def update_state(self, state: Any, response: str) -> Any:
+        """Update the state given the LLM response."""
+
+    @abc.abstractmethod
+    def stop(self, state: Any) -> bool:
+        """Return True if processing should stop."""

--- a/turnip/providers/__init__.py
+++ b/turnip/providers/__init__.py
@@ -1,0 +1,11 @@
+from .base import LLMProvider
+from .openai import OpenAIProvider
+from .together import TogetherProvider
+from .vllm import VLLMProvider
+
+__all__ = [
+    "LLMProvider",
+    "OpenAIProvider",
+    "TogetherProvider",
+    "VLLMProvider",
+]

--- a/turnip/providers/base.py
+++ b/turnip/providers/base.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import abc
+from typing import Any, Dict
+
+class LLMProvider(abc.ABC):
+    """Abstract base class for asynchronous LLM providers."""
+
+    @abc.abstractmethod
+    async def completion(self, prompt: str, **kwargs: Any) -> str:
+        """Return a completion for the given prompt."""
+        raise NotImplementedError

--- a/turnip/providers/openai.py
+++ b/turnip/providers/openai.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.request
+
+from .base import LLMProvider
+
+
+class OpenAIProvider(LLMProvider):
+    """Minimal async OpenAI provider using the HTTP API."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo") -> None:
+        self.model = model
+        self.api_key = os.environ.get("OPENAI_API_KEY", "")
+        self.url = "https://api.openai.com/v1/chat/completions"
+
+    def _post(self, prompt: str) -> str:
+        data = json.dumps({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+        }).encode()
+        req = urllib.request.Request(
+            self.url,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+        )
+        with urllib.request.urlopen(req) as resp:
+            payload = json.load(resp)
+        return payload["choices"][0]["message"]["content"]
+
+    async def completion(self, prompt: str, **kwargs: object) -> str:
+        return await asyncio.to_thread(self._post, prompt)

--- a/turnip/providers/together.py
+++ b/turnip/providers/together.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.request
+
+from .base import LLMProvider
+
+
+class TogetherProvider(LLMProvider):
+    """Provider for Together.ai models."""
+
+    def __init__(self, model: str = "mistralai/Mistral-7B-Instruct-v0.2") -> None:
+        self.model = model
+        self.api_key = os.environ.get("TOGETHER_API_KEY", "")
+        self.url = "https://api.together.xyz/v1/chat/completions"
+
+    def _post(self, prompt: str) -> str:
+        data = json.dumps({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+        }).encode()
+        req = urllib.request.Request(
+            self.url,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+        )
+        with urllib.request.urlopen(req) as resp:
+            payload = json.load(resp)
+        return payload["choices"][0]["message"]["content"]
+
+    async def completion(self, prompt: str, **kwargs: object) -> str:
+        return await asyncio.to_thread(self._post, prompt)

--- a/turnip/providers/vllm.py
+++ b/turnip/providers/vllm.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.request
+
+from .base import LLMProvider
+
+
+class VLLMProvider(LLMProvider):
+    """Provider for vLLM server."""
+
+    def __init__(self, url: str = "http://localhost:8000") -> None:
+        self.url = url.rstrip("/") + "/v1/chat/completions"
+        self.model = os.environ.get("VLLM_MODEL", "")
+        self.api_key = os.environ.get("VLLM_API_KEY", "")
+
+    def _post(self, prompt: str) -> str:
+        data = json.dumps({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+        }).encode()
+        req = urllib.request.Request(
+            self.url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        if self.api_key:
+            req.add_header("Authorization", f"Bearer {self.api_key}")
+        with urllib.request.urlopen(req) as resp:
+            payload = json.load(resp)
+        return payload["choices"][0]["message"]["content"]
+
+    async def completion(self, prompt: str, **kwargs: object) -> str:
+        return await asyncio.to_thread(self._post, prompt)

--- a/turnip/storage.py
+++ b/turnip/storage.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import asyncpg
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    asyncpg = None  # type: ignore
+
+
+@dataclass
+class LLMResult:
+    prompt: str
+    response: str
+
+
+class ResultStore:
+    """Asynchronous result store using PostgreSQL."""
+
+    def __init__(self, dsn: str) -> None:
+        if asyncpg is None:
+            raise RuntimeError("asyncpg is required for ResultStore")
+        self._dsn = dsn
+        self._pool: Optional[asyncpg.Pool] = None
+
+    async def connect(self) -> None:
+        if self._pool is None:
+            self._pool = await asyncpg.create_pool(dsn=self._dsn)
+            await self._init_table()
+
+    async def _init_table(self) -> None:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS llm_results (
+                    prompt TEXT PRIMARY KEY,
+                    response TEXT
+                );
+                """
+            )
+
+    async def fetch(self, prompt: str) -> Optional[LLMResult]:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT prompt, response FROM llm_results WHERE prompt=$1",
+                prompt,
+            )
+            if row:
+                return LLMResult(prompt=row["prompt"], response=row["response"])
+            return None
+
+    async def insert(self, result: LLMResult) -> None:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO llm_results(prompt, response) VALUES ($1, $2)"
+                " ON CONFLICT (prompt) DO NOTHING",
+                result.prompt,
+                result.response,
+            )
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None


### PR DESCRIPTION
## Summary
- set up packaging with `pyproject.toml`
- implement async LLM providers for OpenAI, Together.ai and vLLM
- add a `TurnProcessor` base class supporting caching via PostgreSQL
- document the project goals in `README.md`
- create simple unit tests for processor behaviour and caching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b2f375808322ba93eb1f6d26c520