### PR TITLE
Refactor caching and result storage

### DIFF
--- a/turnip/runner.py
+++ b/turnip/runner.py
@@ -1,70 +1,88 @@
 from __future__ import annotations
 
 import abc
+import hashlib
+import json
 from typing import Any, Optional
 
 from .providers.base import LLMProvider
-from .storage import LLMResult, LLMResponse, ResultStore
+from .storage import (
+    CacheStore,
+    LLMResult,
+    LLMResponse,
+    ResultStore,
+)
 
 
 class ConversationRunner(abc.ABC):
     """Base class for processing an instance using an LLM."""
 
-    def __init__(self, provider: LLMProvider, store: Optional[ResultStore] = None) -> None:
+    def __init__(
+        self,
+        provider: LLMProvider,
+        store: Optional[ResultStore] = None,
+        cache: Optional[CacheStore] = None,
+    ) -> None:
         self.provider = provider
         self.store = store
+        self.cache = cache
 
     async def process(
         self,
         initial_state: Any,
         *,
+        project: str = "default",
         experiment: str = "default",
         run: str = "default",
         instance: str = "default",
         parameters: Optional[dict[str, Any]] = None,
     ) -> Any:
         state = initial_state
+        messages: list[dict[str, str]] = []
+        turn = 0
         while True:
             prompt = self.render_prompt(state)
-            cached = await self._fetch_cached(experiment, run, instance)
-            if cached is not None:
-                response_text = cached.response.content
-            else:
+            messages.append({"role": "user", "content": prompt})
+            cache_key = self._cache_key(messages, parameters)
+            cached_resp = (
+                await self.cache.fetch(cache_key) if self.cache is not None else None
+            )
+            if cached_resp is None:
                 llm_response = await self.provider.completion(
-                    [{"role": "user", "content": prompt}],
+                    messages,
                     **(parameters or {}),
                 )
-                await self._save_result(experiment, run, instance, llm_response)
-                response_text = llm_response.content
-            state = self.update_state(state, response_text)
+                if self.cache is not None:
+                    await self.cache.insert(cache_key, llm_response)
+            else:
+                llm_response = cached_resp
+            if self.store is not None:
+                await self.store.insert(
+                    LLMResult(
+                        project=project,
+                        experiment=experiment,
+                        run=run,
+                        instance=instance,
+                        turn=turn,
+                        cache_key=cache_key,
+                        response=llm_response,
+                    )
+                )
+            messages.append({"role": "assistant", "content": llm_response.content})
+            state = self.update_state(state, llm_response.content)
             if self.stop(state):
                 break
+            turn += 1
         return state
 
-    async def _fetch_cached(
-        self, experiment: str, run: str, instance: str
-    ) -> Optional[LLMResult]:
-        if self.store is None:
-            return None
-        return await self.store.fetch(experiment, run, instance)
+    def _cache_key(
+        self, messages: list[dict[str, str]], parameters: Optional[dict[str, Any]]
+    ) -> str:
+        data = {"messages": messages, "parameters": parameters or {}}
+        payload = json.dumps(data, sort_keys=True).encode()
+        return hashlib.sha256(payload).hexdigest()
 
-    async def _save_result(
-        self,
-        experiment: str,
-        run: str,
-        instance: str,
-        response: LLMResponse,
-    ) -> None:
-        if self.store is None:
-            return
-        await self.store.insert(
-            LLMResult(
-                experiment=experiment,
-                run=run,
-                instance=instance,
-                response=response,
-            )
-        )
+
 
     @abc.abstractmethod
     def render_prompt(self, state: Any) -> str:

--- a/turnip/storage.py
+++ b/turnip/storage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
@@ -23,10 +22,37 @@ class LLMResponse:
 
 @dataclass
 class LLMResult:
+    """Record of a single LLM call within an experiment."""
+
+    project: str
     experiment: str
     run: str
     instance: str
+    turn: int
+    cache_key: str
     response: LLMResponse
+
+
+class CacheStore:
+    """Asynchronous cache for provider responses."""
+
+    async def fetch(self, cache_key: str) -> Optional[LLMResponse]:
+        """Return cached response for the given key if present."""
+        raise NotImplementedError
+
+
+class MemoryCacheStore(CacheStore):
+    """In-memory cache used for testing and simple runs."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, LLMResponse] = {}
+
+    async def fetch(self, cache_key: str) -> Optional[LLMResponse]:
+        return self._data.get(cache_key)
+
+    async def insert(self, cache_key: str, response: LLMResponse) -> None:
+        if cache_key not in self._data:
+            self._data[cache_key] = response
 
 
 class ResultStore:
@@ -49,28 +75,39 @@ class ResultStore:
             await conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS llm_results (
+                    project TEXT,
                     experiment TEXT,
                     run TEXT,
                     instance TEXT,
+                    turn INTEGER,
+                    cache_key TEXT,
                     response JSONB,
-                    PRIMARY KEY (experiment, run, instance)
+                    PRIMARY KEY (project, experiment, run, instance, turn)
                 );
                 """
             )
 
     async def fetch(
-        self, experiment: str, run: str, instance: str
+        self,
+        project: str,
+        experiment: str,
+        run: str,
+        instance: str,
+        turn: int,
     ) -> Optional[LLMResult]:
         assert self._pool is not None
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT response FROM llm_results
-                WHERE experiment=$1 AND run=$2 AND instance=$3
+                SELECT response, cache_key FROM llm_results
+                WHERE project=$1 AND experiment=$2 AND run=$3
+                  AND instance=$4 AND turn=$5
                 """,
+                project,
                 experiment,
                 run,
                 instance,
+                turn,
             )
             if row:
                 data = row["response"]
@@ -81,9 +118,12 @@ class ResultStore:
                     tool_calls=data.get("tool_calls"),
                 )
                 return LLMResult(
+                    project=project,
                     experiment=experiment,
                     run=run,
                     instance=instance,
+                    turn=turn,
+                    cache_key=row["cache_key"],
                     response=resp,
                 )
             return None
@@ -93,13 +133,24 @@ class ResultStore:
         async with self._pool.acquire() as conn:
             await conn.execute(
                 """
-                INSERT INTO llm_results(experiment, run, instance, response)
-                VALUES ($1, $2, $3, $4)
-                ON CONFLICT (experiment, run, instance) DO NOTHING
+                INSERT INTO llm_results(
+                    project,
+                    experiment,
+                    run,
+                    instance,
+                    turn,
+                    cache_key,
+                    response
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                ON CONFLICT (project, experiment, run, instance, turn) DO NOTHING
                 """,
+                result.project,
                 result.experiment,
                 result.run,
                 result.instance,
+                result.turn,
+                result.cache_key,
                 json.dumps(asdict(result.response)),
             )
 
@@ -107,3 +158,34 @@ class ResultStore:
         if self._pool is not None:
             await self._pool.close()
             self._pool = None
+
+
+class MemoryResultStore:
+    """In-memory implementation of ``ResultStore`` for tests."""
+
+    def __init__(self) -> None:
+        self._data: Dict[tuple[str, str, str, str, int], LLMResult] = {}
+
+    async def fetch(
+        self,
+        project: str,
+        experiment: str,
+        run: str,
+        instance: str,
+        turn: int,
+    ) -> Optional[LLMResult]:
+        key = (project, experiment, run, instance, turn)
+        return self._data.get(key)
+
+    async def insert(self, result: LLMResult) -> None:
+        key = (
+            result.project,
+            result.experiment,
+            result.run,
+            result.instance,
+            result.turn,
+        )
+        self._data.setdefault(key, result)
+
+    async def close(self) -> None:  # pragma: no cover - for API compat
+        self._data.clear()


### PR DESCRIPTION
## Summary
- introduce CacheStore and MemoryCacheStore
- extend `ResultStore` schema for projects, runs, instances and turns
- add in-memory ResultStore implementation
- update `ConversationRunner` to use separate cache and result stores
- revise caching test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684203dccbc88322837db2a767bf0f76